### PR TITLE
Typo fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ Note: You need to have composer installed on your system.
             "todopackage\\application\\": "src/"
         }
     ```    
-5. Run ``` composer dumpautoload ``` from your project root.
+5. Run ``` composer dump-autoload ``` from your project root.
 6. Done. Start adding new controllers, models, routes, views to your new package.


### PR DESCRIPTION
Standard syntax for composer dump-autoload (https://getcomposer.org/doc/03-cli.md#dump-autoload)
